### PR TITLE
Adjust encoder and MLP implementation.

### DIFF
--- a/models/transformer.py
+++ b/models/transformer.py
@@ -26,15 +26,19 @@ class EncoderBlock(nn.Module):
             embed_dim=dim, num_heads=attn_heads, dropout=dropout_prob, bias=True
         )
 
-        self.norm = nn.LayerNorm(dim)
+        self.layer_norm1 = nn.LayerNorm(dim)
+        self.layer_norm2 = nn.LayerNorm(dim)
         self.dropout = nn.Dropout(dropout_prob)
         self.mlp = TransformerMlp(dim, dropout_prob, fc_dims)
 
     def forward(self, x):
-        h, attn_weights = self.attn(x, x, x)
-        h = self.norm(h + x)
+        h, _ = self.attn(x, x, x)
+        h = self.dropout(h)
+        h = self.layer_norm1(h + x)
+
         h2 = self.mlp(h)
-        h2 = self.norm(h2 + h)
+        h2 = self.dropout(h2)
+        h2 = self.layer_norm2(h2 + h)
 
         return h2
 

--- a/models/transformer.py
+++ b/models/transformer.py
@@ -1,8 +1,8 @@
-import numpy as np
 import torch
 import torch.nn as nn
 
 from collections import OrderedDict
+
 
 class TransformerMlp(nn.Module):
     def __init__(self, dim, dropout_prob, fc_dims):
@@ -12,14 +12,10 @@ class TransformerMlp(nn.Module):
             nn.GELU(),
             nn.Dropout(dropout_prob),
             nn.Linear(fc_dims, dim),
-            nn.GELU(),
-            nn.Dropout(dropout_prob)
         )
 
     def forward(self, x):
-
         return self.net(x)
-
 
 
 class EncoderBlock(nn.Module):
@@ -27,37 +23,30 @@ class EncoderBlock(nn.Module):
         super(EncoderBlock, self).__init__()
 
         self.attn = nn.MultiheadAttention(
-            embed_dim=dim,
-            num_heads=attn_heads,
-            dropout=dropout_prob,
-            bias=True
+            embed_dim=dim, num_heads=attn_heads, dropout=dropout_prob, bias=True
         )
 
         self.norm = nn.LayerNorm(dim)
         self.dropout = nn.Dropout(dropout_prob)
         self.mlp = TransformerMlp(dim, dropout_prob, fc_dims)
 
-
     def forward(self, x):
-        h = self.norm(x)
-        h, attn_weights = self.attn(h, h, h)
-        h = h + x
-        h2 = self.norm(h)
-        h2 = self.mlp(h2)
-        h2 = h2 + h
+        h, attn_weights = self.attn(x, x, x)
+        h = self.norm(h + x)
+        h2 = self.mlp(h)
+        h2 = self.norm(h2 + h)
+
         return h2
-
-
 
 
 class Transformer(nn.Module):
     def __init__(
-                    self,
-                    dim: int,
-                    attn_heads: int,
-                    dropout_prob: float,
-                    n_enc_blocks: int,
-                    use_global: bool
+        self,
+        dim: int,
+        attn_heads: int,
+        dropout_prob: float,
+        n_enc_blocks: int,
+        use_global: bool,
     ):
         """
 
@@ -70,13 +59,12 @@ class Transformer(nn.Module):
         """
         super(Transformer, self).__init__()
 
-
         self.encoder = self._build_encoders(n_enc_blocks, dim, dropout_prob, attn_heads)
         self.dropout = nn.Dropout(dropout_prob)
         self.use_global = use_global
         if self.use_global:
-            self.h_global = torch.nn.Parameter(torch.rand(1, dim))
-            self.register_parameter(name='global', param=self.h_global)
+            self.h_global = nn.Parameter(torch.rand(1, dim))
+            self.register_parameter(name="global", param=self.h_global)
 
     def _build_encoders(self, n_enc_blocks, dim, dropout_prob, attn_heads):
         """
@@ -91,9 +79,7 @@ class Transformer(nn.Module):
             enc_blocks.append(
                 (f"encoder_{i}", EncoderBlock(dim, dropout_prob, attn_heads, dim))
             )
-        encoder = nn.Sequential(OrderedDict(
-            enc_blocks
-        ))
+        encoder = nn.Sequential(OrderedDict(enc_blocks))
         return encoder
 
     def forward(self, x):
@@ -107,25 +93,21 @@ class Transformer(nn.Module):
             x = torch.cat([h_global, x], dim=1)
         x = x.transpose(0, 1)
         # needs (sequence length, batch size, embedding dimension)
-        #print("before update: ", x[0, 0, :])
+        # print("before update: ", x[0, 0, :])
         h = self.encoder(x)
-        #print("after update", h[0, 0, :])
+        # print("after update", h[0, 0, :])
         return h.transpose(0, 1)
 
 
 class TransformerClassifier(nn.Module):
-
-    def __init__(self, in_dim: int, dim: int, max_seq: int,  transformer: Transformer):
+    def __init__(self, in_dim: int, dim: int, max_seq: int, transformer: Transformer):
         super(TransformerClassifier, self).__init__()
         self.activation = nn.ReLU()
-        self.pos_embedding = nn.Embedding(
-            num_embeddings=max_seq, embedding_dim=dim
-        )
+        self.pos_embedding = nn.Embedding(num_embeddings=max_seq, embedding_dim=dim)
         self.linear = nn.Linear(in_dim, dim)
         self.transformer = transformer
         self.output = nn.Linear(dim, 2)
         self.softmax = nn.Softmax(dim=-1)
-
 
     def forward(self, x, p):
         h = self.activation(self.linear(x))
@@ -141,15 +123,18 @@ class TransformerClassifier(nn.Module):
 
     @classmethod
     def build(cls, in_dim, h_dim, attn_heads, encoder_blocks, max_seq_len):
-        t = Transformer(
+        transformer = Transformer(
             dim=h_dim,
             attn_heads=attn_heads,
             n_enc_blocks=encoder_blocks,
             dropout_prob=0.0,
-            use_global=True
+            use_global=True,
         )
-        model = TransformerClassifier(in_dim, dim=h_dim, transformer=t, max_seq=max_seq_len)
+        model = TransformerClassifier(
+            in_dim, dim=h_dim, transformer=transformer, max_seq=max_seq_len
+        )
         return model
+
 
 if __name__ == "__main__":
     # needs (batch size, sequence length, channels)
@@ -157,11 +142,7 @@ if __name__ == "__main__":
     p = torch.arange(0, 5, dtype=torch.long)
     d = 128
     t = Transformer(
-        dim=d,
-        attn_heads=8,
-        n_enc_blocks=1,
-        dropout_prob=0.0,
-        use_global=True
+        dim=d, attn_heads=8, n_enc_blocks=1, dropout_prob=0.0, use_global=True
     )
     model = TransformerClassifier(40, dim=d, transformer=t, max_seq=5)
     y = model(x, p)

--- a/transformer_experiment.py
+++ b/transformer_experiment.py
@@ -18,19 +18,19 @@ from models.transformer import TransformerClassifier
 # Build dataset
 params = {
     "class_0": {
-        'a': 2.0,
-        'b': 0.5,
-        'c': 1,
-        'd': 0,
-        'eps': 0.5
+        "a": 2.0,
+        "b": 0.5,
+        "c": 1,
+        "d": 0,
+        "eps": 0.5,
     },
     "class_1": {
-        'a': 1.8,
-        'b': 0.5,
-        'c': 1.0,
-        'd': 0,
-        'eps': 0.5
-    }
+        "a": 1.8,
+        "b": 0.5,
+        "c": 1.0,
+        "d": 0,
+        "eps": 0.5,
+    },
 }
 n = 1000
 l = 100
@@ -50,15 +50,11 @@ batch_size = 8
 weight_decay = 0.01
 lr = 3e-4
 
-k = 20 # chunk/kernel size
-d = 128 # hidden dim
+k = 20  # chunk/kernel size
+d = 128  # hidden dim
 
 model = TransformerClassifier.build(
-    in_dim=k*2,
-    h_dim=d,
-    attn_heads=8,
-    encoder_blocks=1,
-    max_seq_len= l // k
+    in_dim=k * 2, h_dim=d, attn_heads=8, encoder_blocks=1, max_seq_len=l // k
 )
 
 n_params = get_n_params(model)
@@ -95,7 +91,9 @@ for e in tqdm(range(n_epochs)):
         loss_queue.add(float(loss.detach().data.numpy()))
         loss_arr.append(loss_queue.mean())
 
-        acc = np.mean((torch.argmax(F.softmax(y_hat, dim=-1), dim=-1) == target).data.numpy())
+        acc = np.mean(
+            (torch.argmax(F.softmax(y_hat, dim=-1), dim=-1) == target).data.numpy()
+        )
         acc_queue.add(acc)
 
         acc_arr.append(acc_queue.mean())
@@ -112,7 +110,11 @@ for e in tqdm(range(n_epochs)):
     test_y_hat_all = torch.cat(test_y_hat_list)
     test_target_all = torch.cat(test_target_list)
 
-    test_acc = np.mean((torch.argmax(F.softmax(test_y_hat_all, dim=-1), dim=-1) == test_target_all).data.numpy())
+    test_acc = np.mean(
+        (
+            torch.argmax(F.softmax(test_y_hat_all, dim=-1), dim=-1) == test_target_all
+        ).data.numpy()
+    )
     test_acc_arr.append(test_acc)
 
 plt.plot(np.arange(len(loss_arr)), loss_arr)
@@ -125,14 +127,14 @@ plt.plot(np.arange(len(acc_arr)), acc_arr)
 plt.xlabel("iteration")
 plt.ylabel("Accuracy")
 plt.title("Train Accuracy")
-plt.axhline(acc_arr[-1], c='red', linestyle='--')
+plt.axhline(acc_arr[-1], c="red", linestyle="--")
 plt.show()
 
 
 plt.plot(np.arange(len(test_acc_arr)), test_acc_arr)
 plt.xlabel("Epoch")
 plt.ylabel("Accuracy")
-plt.axhline(np.mean(test_acc_arr[-5:]), c='red', linestyle='--')
+plt.axhline(np.mean(test_acc_arr[-5:]), c="red", linestyle="--")
 plt.title("Test Accuracy")
 plt.show()
 


### PR DESCRIPTION
Two main change:

1. Removed second GELU and dropout in the MLP to match [the annotated transformer](https://nlp.seas.harvard.edu/2018/04/03/attention.html).
2. Reordered the Encoder forward pass and split the layer norm into two separate modules (because they each have their own learned parameters).

All other changes are formatting changes because I have an auto-formatter in vscode, so you can ignore those.

I tested the code with and without the changes, and they have similar test accuracy. So, in practice, these changes might be insignificant, but they now meet the specs more closely.